### PR TITLE
fix: update serialization to use jackson

### DIFF
--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
@@ -14,6 +14,7 @@ import com.aws.greengrass.mqttclient.v5.UserProperty;
 import com.aws.greengrass.util.NucleusPaths;
 import com.aws.greengrass.util.RetryUtils;
 import com.aws.greengrass.util.SerializerFactory;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.sqlite.SQLiteErrorCode;
 
@@ -29,7 +30,6 @@ import java.sql.Statement;
 import java.sql.Types;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -251,9 +251,9 @@ public class DiskSpoolDAO {
                     .responseTopic(rs.getString("responseTopic"))
                     .correlationData(rs.getBytes("correlationData"))
                     .contentType(rs.getString("contentType"))
-                    .userProperties(rs.getString("userProperties") == null ? null :
-                            Arrays.asList(mapper.readValue(rs.getString("userProperties"),
-                            UserProperty[].class))).build();
+                    .userProperties(rs.getString("userProperties") == null
+                            ? null : mapper.readValue(rs.getString("userProperties"),
+                                    new TypeReference<List<UserProperty>>(){})).build();
 
             return SpoolMessage.builder()
                     .id(messageId)

--- a/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolUnitTest.java
+++ b/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolUnitTest.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -252,19 +251,7 @@ public class DiskSpoolUnitTest extends BaseITCase {
                         .build();
         long id1 = spool.addMessage(request).getId();
         Publish response = spool.getMessageById(id1).getRequest();
-        String result_string = new String(response.getPayload(), StandardCharsets.UTF_8);
-        List<UserProperty> result_list = response.getUserProperties();
-        assertEquals(message, result_string);
-        assertEquals(props, result_list);
-        assertEquals(request.getTopic(), response.getTopic());
-        assertEquals(request.getQos(), response.getQos());
-        assertEquals(request.getMessageExpiryIntervalSeconds(), response.getMessageExpiryIntervalSeconds());
-        assertEquals(request.getResponseTopic(), response.getResponseTopic());
-        assertEquals(request.getContentType(), response.getContentType());
-        assertArrayEquals(request.getCorrelationData(), response.getCorrelationData());
-        assertEquals(request.getPayloadFormat(), response.getPayloadFormat());
-        assertEquals(request.getUserProperties(), response.getUserProperties());
-        assertEquals(request.isRetain(), response.isRetain());
+        assertEquals(request, response);
     }
     @Test
     void GIVEN_request_with_MQTT3_fields_WHEN_add_to_spool_and_extract_THEN_MQTT5_fields_should_be_null()
@@ -274,15 +261,6 @@ public class DiskSpoolUnitTest extends BaseITCase {
                 Publish.builder().topic("spool").payload(message.getBytes(StandardCharsets.UTF_8)).qos(QOS.AT_LEAST_ONCE).build();
         long id1 = spool.addMessage(request).getId();
         Publish response = spool.getMessageById(id1).getRequest();
-        assertNull(response.getMessageExpiryIntervalSeconds());
-        assertNull(response.getResponseTopic());
-        assertNull(response.getContentType());
-        assertNull(response.getCorrelationData());
-        assertNull(response.getPayloadFormat());
-        assertNull(response.getUserProperties());
-        String result_string = new String(response.getPayload(), StandardCharsets.UTF_8);
-        assertEquals("Hello", result_string);
-        assertEquals(request.getTopic(), response.getTopic());
-        assertEquals(request.getQos(), response.getQos());
+        assertEquals(request, response);
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated how we serialize and deserialize userProperties to be safer by using Jackson. Also created a new unit test and fixed resultSet's behavior with null values.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
