### PR TITLE
feat: call executeQueueSync in startup

### DIFF
--- a/src/integrationtests/resources/com/aws/greengrass/integrationtests/config.yaml
+++ b/src/integrationtests/resources/com/aws/greengrass/integrationtests/config.yaml
@@ -7,3 +7,12 @@ services:
         spooler:
           storageType: Disk
           maxSizeInBytes: 25
+  aws.greengrass.DiskSpooler:
+    configuration:
+  main:
+    lifecycle:
+      install:
+        all: echo All installed
+    dependencies:
+        - aws.greengrass.DiskSpooler
+        - aws.greengrass.Nucleus

--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
@@ -12,6 +12,7 @@ import com.aws.greengrass.lifecyclemanager.PluginService;
 import com.aws.greengrass.logging.api.Logger;
 import com.aws.greengrass.logging.impl.LogManager;
 import com.aws.greengrass.mqttclient.spool.CloudMessageSpool;
+import com.aws.greengrass.mqttclient.spool.Spool;
 import com.aws.greengrass.mqttclient.spool.SpoolMessage;
 
 import java.io.IOException;
@@ -41,6 +42,7 @@ public class DiskSpool extends PluginService implements CloudMessageSpool {
     public void startup() {
         try {
             dao.setUpDatabase();
+            context.get(Spool.class).executeQueueSync(this);
             reportState(State.RUNNING);
         } catch (SQLException e) {
             serviceErrored(e);

--- a/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolUnitTest.java
+++ b/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolUnitTest.java
@@ -42,6 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
 
+// TODO: Refactor to correctly use the Class under test (probably remove some tests as well,
+//  as spooler behavior shouldn't be tested here but in Nucleus)
 @ExtendWith({GGExtension.class, MockitoExtension.class})
 public class DiskSpoolUnitTest extends BaseITCase {
     @TempDir
@@ -207,28 +209,6 @@ public class DiskSpoolUnitTest extends BaseITCase {
         assertThrows(SpoolerStoreException.class, () -> spool.addMessage(request));
     }
 
-    @Test
-    void GIVEN_requests_added_to_spooler_WHEN_spooler_restarts_THEN_queue_should_persist()
-            throws SpoolerStoreException, InterruptedException, IOException {
-        String message = "Hello";
-        Publish request =
-                Publish.builder().topic("spool").payload(message.getBytes(StandardCharsets.UTF_8))
-                        .qos(QOS.AT_LEAST_ONCE).build();
-        long id1 = spool.addMessage(request).getId();
-        long id2 = spool.addMessage(request).getId();
-        long id3 = spool.addMessage(request).getId();
-        assertEquals(spool.getCurrentMessageCount(), 3);
-
-        runLast();
-        runFirst();
-
-        //check length of RAM queue (we expect this to be synced with the db)
-        assertEquals(3, spool.getCurrentMessageCount());
-        //check the specific ids stored in spooler
-        assertEquals(id1, popAndRemoveNextId());
-        assertEquals(id2, popAndRemoveNextId());
-        assertEquals(id3, popAndRemoveNextId());
-    }
     @Test
     void GIVEN_request_with_MQTT5_fields_WHEN_add_to_spool_and_extract_THEN_fields_should_stay_the_same()
             throws InterruptedException, SpoolerStoreException {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
ExecuteQueueSync (Sync message IDs from Database to Spool's local list of IDs that we maintain), once Database setup has been done.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
