### PR TITLE
chore: enable integration tests

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/DiskSpoolIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/DiskSpoolIntegrationTest.java
@@ -19,7 +19,6 @@ import com.aws.greengrass.mqttclient.v5.QOS;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,8 +43,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith({GGExtension.class, MockitoExtension.class})
-// TODO: Enable after Plugin loading changed in Nucleus
-@Disabled
 public class DiskSpoolIntegrationTest extends BaseITCase {
     @TempDir
     Path rootDir;
@@ -62,6 +59,7 @@ public class DiskSpoolIntegrationTest extends BaseITCase {
 
     @BeforeEach
     void beforeEach() throws InterruptedException, IOException {
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         startKernelWithConfig();
         spoolerDatabaseFile = kernel.getNucleusPaths()
                 .workPath(DiskSpool.PERSISTENCE_SERVICE_NAME)

--- a/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolUnitTest.java
+++ b/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolUnitTest.java
@@ -71,6 +71,7 @@ public class DiskSpoolUnitTest extends BaseITCase {
     }
 
     private void runFirst() throws InterruptedException {
+        System.setProperty("aws.greengrass.scanSelfClasspath", "true");
         startKernelWithConfig();
         config.lookup("spooler", GG_SPOOL_MAX_SIZE_IN_BYTES_KEY).withValue(25L);
         config.lookup("spooler", GG_SPOOL_STORAGE_TYPE_KEY).withValue(String.valueOf(SpoolerStorageType.Disk));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Enable Integration tests
- `"aws.greengrass.scanSelfClasspath"` is now needed as it's removed from `BaseITCase` class

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
