### PR TITLE
fix: sync get, add and remove calls

### DIFF
--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
@@ -102,7 +102,7 @@ public class DiskSpoolDAO {
      * @throws SQLException when fails to get a SpoolMessage by id
      */
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    public SpoolMessage getSpoolMessageById(long messageId) throws SQLException {
+    public synchronized SpoolMessage getSpoolMessageById(long messageId) throws SQLException {
         String query = "SELECT retried, topic, qos, retain, payload, userProperties, messageExpiryIntervalSeconds, "
                 + "correlationData, responseTopic, payloadFormat, contentType FROM spooler WHERE message_id = ?;";
         try (Connection conn = getDbInstance();
@@ -126,7 +126,7 @@ public class DiskSpoolDAO {
      * @throws SQLException when fails to insert SpoolMessage in the database
      */
     @SuppressWarnings({"PMD.ExceptionAsFlowControl", "PMD.AvoidCatchingGenericException"})
-    public void insertSpoolMessage(SpoolMessage message) throws SQLException {
+    public synchronized void insertSpoolMessage(SpoolMessage message) throws SQLException {
         String sqlString =
                 "INSERT INTO spooler (message_id, retried, topic, qos, retain, payload, userProperties, "
                         + "messageExpiryIntervalSeconds, correlationData, responseTopic, payloadFormat, contentType) "
@@ -193,7 +193,7 @@ public class DiskSpoolDAO {
      * @throws SQLException when fails to remove a SpoolMessage by id
      */
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
-    public void removeSpoolMessageById(Long messageId) throws SQLException {
+    public synchronized void removeSpoolMessageById(Long messageId) throws SQLException {
         String deleteSQL = "DELETE FROM spooler WHERE message_id = ?;";
         try (Connection conn = getDbInstance();
             PreparedStatement pstmt = conn.prepareStatement(deleteSQL)) {


### PR DESCRIPTION
*Issue #, if available:*
Testing at 100 TPS, we see multiple instances of SQLITE_BUSY errors while trying to add, get or remove from spooler. We should be avoiding this by not accessing Database file in parallel.
*Description of changes:*
Add `synchronized` to get, add and remove methods of `dao` object so that these are not executed simultaneously and  avoid parallel calls to Database. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
