### PR TITLE
perf: reuse database connection across requests

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/DiskSpoolIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/DiskSpoolIntegrationTest.java
@@ -117,7 +117,7 @@ public class DiskSpoolIntegrationTest extends BaseITCase {
 
     @Test
     void GIVEN_disk_spool_plugin_WHEN_operation_fails_with_database_corruption_THEN_database_recreated_AND_next_operation_successful()
-            throws IOException {
+            throws IOException, SQLException {
 
         deviceConfiguration = new DeviceConfiguration(kernel);
         dao = new DiskSpoolDAO(kernel.getNucleusPaths());

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/DiskSpoolIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/DiskSpoolIntegrationTest.java
@@ -39,7 +39,6 @@ import java.util.concurrent.TimeUnit;
 
 import static java.nio.file.Files.deleteIfExists;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith({GGExtension.class, MockitoExtension.class})
@@ -116,7 +115,7 @@ public class DiskSpoolIntegrationTest extends BaseITCase {
     }
 
     @Test
-    void GIVEN_disk_spool_plugin_WHEN_operation_fails_with_database_corruption_THEN_database_recreated_AND_next_operation_successful()
+    void GIVEN_disk_spool_plugin_WHEN_database_corrupted_THEN_database_recreated_AND_next_operation_successful()
             throws IOException, SQLException {
 
         deviceConfiguration = new DeviceConfiguration(kernel);
@@ -127,8 +126,6 @@ public class DiskSpoolIntegrationTest extends BaseITCase {
         Publish request1 = createTestPublishRequestWithMessage(message1);
         String message2 = "Message2";
         Publish request2 = createTestPublishRequestWithMessage(message2);
-        String message3 = "Message3";
-        Publish request3 = createTestPublishRequestWithMessage(message3);
 
         // Add first message
         SpoolMessage spoolMessage1 = SpoolMessage.builder().id(1L).request(request1).build();
@@ -142,15 +139,11 @@ public class DiskSpoolIntegrationTest extends BaseITCase {
             f.writeBytes("Garbage");
         }
 
-        // Fail to add second message
-        SpoolMessage spoolMessage2 = SpoolMessage.builder().id(2L).request(request2).build();
-        assertThrows(IOException.class, () -> diskSpool.add(2L, spoolMessage2));
-
-        // Successfully add third Message
-        SpoolMessage spoolMessage3 = SpoolMessage.builder().id(3L).request(request3).build();
-        diskSpool.add(3L, spoolMessage3);
-        String readMessage3 = new String (diskSpool.getMessageById(3L).getRequest().getPayload(), StandardCharsets.UTF_8);
-        assertEquals(message3, readMessage3);
+        // Successfully add Second Message
+        SpoolMessage spoolMessage3 = SpoolMessage.builder().id(2L).request(request2).build();
+        diskSpool.add(2L, spoolMessage3);
+        String readMessage3 = new String (diskSpool.getMessageById(2L).getRequest().getPayload(), StandardCharsets.UTF_8);
+        assertEquals(message2, readMessage3);
     }
 
     @Test

--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
@@ -30,6 +30,16 @@ public class DiskSpool extends PluginService implements CloudMessageSpool {
         this.dao = dao;
     }
 
+    @Override
+    public void shutdown() throws InterruptedException {
+        // Close the database connection
+        try {
+            dao.close();
+        } catch (SQLException e) {
+            logger.atError().cause(e).log("Failed to close database connection during service shutdown");
+        }
+        super.shutdown();
+    }
     /**
      * This function takes an id and returns a SpoolMessage from the db with the same id.
      * @param id : id assigned to MQTT message

--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
@@ -21,7 +21,7 @@ import javax.inject.Inject;
 public class DiskSpool extends PluginService implements CloudMessageSpool {
 
     public static final String PERSISTENCE_SERVICE_NAME = "aws.greengrass.DiskSpooler";
-    private static final Logger logger = LogManager.getLogger(DiskSpool.class);
+    static final Logger logger = LogManager.getLogger(DiskSpool.class);
     private final DiskSpoolDAO dao;
 
     @Inject

--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
@@ -45,6 +45,7 @@ public class DiskSpool extends PluginService implements CloudMessageSpool {
      * @param id : id assigned to MQTT message
      * @return payload of the MQTT message stored with id
      */
+
     @Override
     public SpoolMessage getMessageById(long id) {
         try {

--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
@@ -21,7 +21,7 @@ import javax.inject.Inject;
 public class DiskSpool extends PluginService implements CloudMessageSpool {
 
     public static final String PERSISTENCE_SERVICE_NAME = "aws.greengrass.DiskSpooler";
-    static final Logger logger = LogManager.getLogger(DiskSpool.class);
+    private static final Logger logger = LogManager.getLogger(DiskSpool.class);
     private final DiskSpoolDAO dao;
 
     @Inject

--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
@@ -253,6 +253,12 @@ public class DiskSpoolDAO {
         try (LockScope ignored = LockScope.lock(dbConnectionLock.writeLock())) {
             if (dbConnection != null && !dbConnection.isClosed()) {
                 dbConnection.close();
+                if (dbConnection.isClosed()) {
+                    logger.atWarn().log("Confirmed: Database connection is truly closed.");
+                } else {
+                    logger.atError().log("Error: Database connection is NOT closed.");
+
+                }
             }
         }
     }
@@ -334,13 +340,7 @@ public class DiskSpoolDAO {
             try {
                 logger.atWarn().log(String.format("Database %s is corrupted, creating new database", databasePath));
                 logger.atWarn().log("Attempting to close the database connection.");
-                dbConnection.close();
-                if (dbConnection.isClosed()) {
-                    logger.atWarn().log("Confirmed: Database connection is truly closed.");
-                } else {
-                    logger.atError().log("Error: Database connection is NOT closed.");
-
-                }
+                close();
                 logger.atWarn().log("Database connection closed.");
                 logger.atWarn().log("Attempting to delete the database file.");
                 Thread.sleep(5000);

--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
@@ -334,16 +334,23 @@ public class DiskSpoolDAO {
             try {
                 logger.atWarn().log(String.format("Database %s is corrupted, creating new database", databasePath));
                 logger.atWarn().log("Attempting to close the database connection.");
-                close();
+                dbConnection.close();
+                if (dbConnection.isClosed()) {
+                    logger.atWarn().log("Confirmed: Database connection is truly closed.");
+                } else {
+                    logger.atError().log("Error: Database connection is NOT closed.");
+
+                }
                 logger.atWarn().log("Database connection closed.");
                 logger.atWarn().log("Attempting to delete the database file.");
+                Thread.sleep(5000);
                 deleteIfExists(databasePath);
                 logger.atWarn().log("Database file deleted.");
                 logger.atWarn().log("Initializing a new database connection.");
                 init();
                 logger.atWarn().log("Initialized a new database connection.");
                 setUpDatabase();
-            } catch (IOException e2) {
+            } catch (IOException | InterruptedException e2) {
                 throw new SQLException(e2);
             } finally {
                 recoverDBLock.unlock();

--- a/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOTest.java
+++ b/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOTest.java
@@ -10,6 +10,7 @@ import com.aws.greengrass.mqttclient.v5.Publish;
 import com.aws.greengrass.mqttclient.v5.QOS;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.NucleusPaths;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -47,7 +48,12 @@ public class DiskSpoolDAOTest {
     @Mock
     private NucleusPaths paths;
 
-
+    @AfterEach
+    public void cleanup() throws SQLException {
+        if (dbConnection != null && !dbConnection.isClosed()) {
+            dbConnection.close();
+        }
+    }
 
     @Test
     void GIVEN_request_with_text_WHEN_operation_to_spool_fail_and_DB_corrupt_THEN_should_recover_DB()
@@ -76,8 +82,6 @@ public class DiskSpoolDAOTest {
         assertThrows(SQLException.class, () -> diskSpoolDAO.insertSpoolMessage(spoolMessage));
         verify(diskSpoolDAO, times(1)).checkAndHandleCorruption(sqlException);
         assertDoesNotThrow(() ->diskSpoolDAO.insertSpoolMessage(spoolMessage));
-        dbConnection.close();
-        verify(dbConnection, times(1)).close();
     }
 
     @Test
@@ -108,7 +112,5 @@ public class DiskSpoolDAOTest {
 
         SpoolMessage spoolMessage = SpoolMessage.builder().id(1L).request(request).build();
         assertDoesNotThrow(() -> diskSpoolDAO.insertSpoolMessage(spoolMessage));
-        dbConnection.close();
-        verify(dbConnection, times(1)).close();
     }
 }

--- a/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOTest.java
+++ b/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOTest.java
@@ -18,6 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.sql.Connection;
@@ -30,11 +31,8 @@ import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+
 
 @ExtendWith({GGExtension.class, MockitoExtension.class})
 public class DiskSpoolDAOTest {
@@ -43,7 +41,7 @@ public class DiskSpoolDAOTest {
     @Mock
     private Statement statement;
     @Mock
-    private Connection connection;
+    volatile Connection dbConnection;
     @TempDir
     Path currDir;
     @Mock
@@ -51,18 +49,20 @@ public class DiskSpoolDAOTest {
 
     @Test
     void GIVEN_request_with_text_WHEN_operation_to_spool_fail_and_DB_corrupt_THEN_should_recover_DB()
-            throws SQLException, IOException {
+            throws SQLException, IOException, NoSuchFieldException, IllegalAccessException {
         SQLException sqlException = new SQLException("DB is corrupt", "some state", 11);
         lenient().when(paths.workPath(anyString())).thenReturn(currDir);
-        lenient().when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
-        lenient().when(connection.createStatement()).thenReturn(statement);
+        lenient().when(dbConnection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        lenient().when(dbConnection.createStatement()).thenReturn(statement);
         lenient().when(preparedStatement.executeUpdate())
                 .thenThrow(sqlException)
                 .thenReturn(0);
         lenient().when(statement.executeUpdate(anyString())).thenReturn(0);
 
         DiskSpoolDAO diskSpoolDAO = spy(new DiskSpoolDAO(paths));
-        doReturn(connection).when(diskSpoolDAO).getDbInstance();
+        Field field = DiskSpoolDAO.class.getDeclaredField("dbConnection");
+        field.setAccessible(true);
+        field.set(diskSpoolDAO, dbConnection);
 
         String message = "Hello";
         Publish request =
@@ -78,12 +78,12 @@ public class DiskSpoolDAOTest {
 
     @Test
     void GIVEN_request_with_text_WHEN_operation_to_spool_fail_and_transient_error_THEN_should_retry(ExtensionContext context)
-            throws SQLException, IOException {
+            throws SQLException, IOException, NoSuchFieldException, IllegalAccessException {
         ignoreExceptionOfType(context, SQLTransientException.class);
         SQLException sqlException = new SQLTransientException("Some Transient Error");
         lenient().when(paths.workPath(anyString())).thenReturn(currDir);
-        lenient().when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
-        lenient().when(connection.createStatement()).thenReturn(statement);
+        lenient().when(dbConnection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        lenient().when(dbConnection.createStatement()).thenReturn(statement);
         // Fail the first two times to check retry behavior
         lenient().when(preparedStatement.executeUpdate())
                 .thenThrow(sqlException)
@@ -92,7 +92,9 @@ public class DiskSpoolDAOTest {
         lenient().when(statement.executeUpdate(anyString())).thenReturn(0);
 
         DiskSpoolDAO diskSpoolDAO = spy(new DiskSpoolDAO(paths));
-        doReturn(connection).when(diskSpoolDAO).getDbInstance();
+        Field field = DiskSpoolDAO.class.getDeclaredField("dbConnection");
+        field.setAccessible(true);
+        field.set(diskSpoolDAO, dbConnection);
 
         String message = "Hello";
         Publish request =

--- a/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOTest.java
+++ b/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOTest.java
@@ -10,7 +10,6 @@ import com.aws.greengrass.mqttclient.v5.Publish;
 import com.aws.greengrass.mqttclient.v5.QOS;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
 import com.aws.greengrass.util.NucleusPaths;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -21,7 +20,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -49,19 +47,6 @@ public class DiskSpoolDAOTest {
     @Mock
     private NucleusPaths paths;
 
-    @AfterEach
-    public void cleanup() throws SQLException, IOException {
-        if (dbConnection != null && !dbConnection.isClosed()) {
-            dbConnection.close();
-        }
-        Path toBeDeleted = currDir.resolve("spooler.db").toAbsolutePath();
-        if (Files.exists(toBeDeleted)) {
-            Path tempPath = toBeDeleted.resolveSibling(toBeDeleted.getFileName() + ".toDelete");
-            Files.move(toBeDeleted, tempPath);
-            tempPath.toFile().deleteOnExit();
-        }
-
-    }
 
     @Test
     void GIVEN_request_with_text_WHEN_operation_to_spool_fail_and_DB_corrupt_THEN_should_recover_DB()
@@ -88,10 +73,6 @@ public class DiskSpoolDAOTest {
 
         SpoolMessage spoolMessage = SpoolMessage.builder().id(1L).request(request).build();
         assertThrows(SQLException.class, () -> diskSpoolDAO.insertSpoolMessage(spoolMessage));
-        if (dbConnection != null) {
-            dbConnection.close();
-        }
-        Thread.sleep(1000);
         verify(diskSpoolDAO, times(1)).checkAndHandleCorruption(sqlException);
         assertDoesNotThrow(() ->diskSpoolDAO.insertSpoolMessage(spoolMessage));
     }

--- a/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOTest.java
+++ b/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOTest.java
@@ -64,6 +64,9 @@ public class DiskSpoolDAOTest {
         Field field = DiskSpoolDAO.class.getDeclaredField("dbConnection");
         field.setAccessible(true);
         field.set(diskSpoolDAO, dbConnection);
+        doNothing().when(diskSpoolDAO).close();
+        doNothing().when(diskSpoolDAO).init();
+
 
         String message = "Hello";
         Publish request =


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added shutdown method to close the Database connection.
Added singleton pattern for the database connection(dbConnection) within DiskSpoolDAO class. Each of the method uses this singleton connection and synchronized.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
