### PR TITLE
chore: improve dao unit test coverage

### DIFF
--- a/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOTest.java
+++ b/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOTest.java
@@ -22,8 +22,15 @@ import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLTransientException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 import static com.aws.greengrass.testcommons.testutilities.ExceptionLogProtector.ignoreExceptionOfType;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -46,6 +53,44 @@ class DiskSpoolDAOTest {
         Connection conn = dao.getConnection();
         if (conn != null) {
             conn.close();
+        }
+    }
+
+    @Test
+    void GIVEN_empty_spooler_WHEN_messages_added_and_removed_from_spooler_THEN_success() throws SQLException {
+        List<Long> messageIds = LongStream.range(0, 100L).boxed().collect(Collectors.toList());
+
+        // fill db with messages
+        for (long id : messageIds) {
+            dao.insertSpoolMessage(
+                    SpoolMessage.builder()
+                            .id(id)
+                            .request(
+                                    Publish.builder()
+                                            .topic("spool")
+                                            .payload("Hello".getBytes(StandardCharsets.UTF_8))
+                                            .qos(QOS.AT_LEAST_ONCE)
+                                            .messageExpiryIntervalSeconds(2L)
+                                            .payloadFormat(Publish.PayloadFormatIndicator.BYTES)
+                                            .contentType("Test")
+                                            .build())
+                            .build());
+            // verify message exists
+            assertNotNull(dao.getSpoolMessageById(id));
+        }
+
+        // verify getting all ids
+        int numMessagesChecked = 0;
+        Iterator<Long> persistedIds = dao.getAllSpoolMessageIds().iterator();
+        for (int i = 0; i < messageIds.size(); i++, numMessagesChecked++) {
+            assertEquals(messageIds.get(i), persistedIds.next());
+        }
+        assertEquals(messageIds.size(), numMessagesChecked);
+
+        // remove everything
+        for (long id : messageIds) {
+            dao.removeSpoolMessageById(id);
+            assertNull(dao.getSpoolMessageById(id));
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add basic coverage for DiskSpoolerDAO in unit tests.  Test that simply adds, verifies, and removes messages from the db.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
