### PR TITLE
feat: use single db connection

### DIFF
--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/DiskSpoolIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/DiskSpoolIntegrationTest.java
@@ -17,6 +17,7 @@ import com.aws.greengrass.mqttclient.v5.Publish;
 import com.aws.greengrass.mqttclient.v5.QOS;
 import com.aws.greengrass.mqttclient.v5.UserProperty;
 import com.aws.greengrass.testcommons.testutilities.GGExtension;
+import com.aws.greengrass.util.Utils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -243,8 +244,7 @@ class DiskSpoolIntegrationTest {
 
         // Corrupt Database
         try (RandomAccessFile f = new RandomAccessFile(spoolerDatabaseFile.toFile(), "rw")) {
-            f.seek(100);
-            f.writeBytes("Garbage");
+            f.writeBytes(Utils.generateRandomString(256));
         }
 
         // Fail to add second message

--- a/src/integrationtests/java/com/aws/greengrass/integrationtests/DiskSpoolIntegrationTest.java
+++ b/src/integrationtests/java/com/aws/greengrass/integrationtests/DiskSpoolIntegrationTest.java
@@ -39,7 +39,6 @@ import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static java.nio.file.Files.deleteIfExists;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -67,8 +66,8 @@ class DiskSpoolIntegrationTest {
     }
 
     @AfterEach
-    void afterEach() throws IOException {
-        stopNucleus(true);
+    void afterEach() {
+        kernel.shutdown();
     }
 
     @Test
@@ -184,7 +183,7 @@ class DiskSpoolIntegrationTest {
         spooler.addMessage(publishRequestFromPayload(payload3));
 
         // restart nucleus
-        stopNucleus(false);
+        kernel.shutdown();
         startNucleus();
 
         // Read messages
@@ -265,16 +264,6 @@ class DiskSpoolIntegrationTest {
                 .workPath(DiskSpool.PERSISTENCE_SERVICE_NAME).resolve(DATABASE_FILE_NAME);
         diskSpool = kernel.getContext().get(DiskSpool.class);
         spooler = new Spool(kernel.getContext().get(DeviceConfiguration.class), kernel);
-    }
-
-    void stopNucleus(boolean clearSpoolDb) throws IOException {
-        try {
-            if (clearSpoolDb) {
-                deleteIfExists(spoolerDatabaseFile);
-            }
-        } finally {
-            kernel.shutdown();
-        }
     }
 
     private void startKernelWithConfig() throws InterruptedException {

--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
@@ -37,12 +37,9 @@ public class DiskSpool extends PluginService implements CloudMessageSpool {
      * @return payload of the MQTT message stored with id
      */
     @Override
-    public SpoolMessage getMessageById(long id) { // TODO support InterruptedException in interface
+    public SpoolMessage getMessageById(long id) {
         try {
             return dao.getSpoolMessageById(id);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            return null;
         } catch (SQLException e) {
             logger.atError()
                     .kv(KV_MESSAGE_ID, id)
@@ -62,7 +59,7 @@ public class DiskSpool extends PluginService implements CloudMessageSpool {
         try {
             dao.removeSpoolMessageById(id);
             logger.atTrace().kv(KV_MESSAGE_ID, id).log("Removed message from Disk Spooler");
-        } catch (SQLException | InterruptedException e) { // TODO support InterruptedException in interface
+        } catch (SQLException e) {
             logger.atWarn()
                     .kv(KV_MESSAGE_ID, id)
                     .cause(e)
@@ -80,7 +77,7 @@ public class DiskSpool extends PluginService implements CloudMessageSpool {
         try {
             dao.insertSpoolMessage(message);
             logger.atTrace().kv(KV_MESSAGE_ID, id).log("Added message to Disk Spooler");
-        } catch (SQLException | InterruptedException e) { // TODO support InterruptedException in interface
+        } catch (SQLException e) {
             throw new IOException(e);
         }
     }
@@ -89,7 +86,7 @@ public class DiskSpool extends PluginService implements CloudMessageSpool {
     public Iterable<Long> getAllMessageIds() throws IOException {
         try {
             return dao.getAllSpoolMessageIds();
-        } catch (SQLException | InterruptedException e) {
+        } catch (SQLException e) {
             throw new IOException(e);
         }
     }
@@ -100,7 +97,7 @@ public class DiskSpool extends PluginService implements CloudMessageSpool {
             dao.initialize();
             dao.setUpDatabase();
             logger.atInfo().log("Finished setting up Database");
-        } catch (SQLException | InterruptedException e) { // TODO support InterruptedException in interface
+        } catch (SQLException e) {
             throw new IOException(e);
         }
     }

--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpool.java
@@ -104,4 +104,10 @@ public class DiskSpool extends PluginService implements CloudMessageSpool {
             throw new IOException(e);
         }
     }
+
+    @Override
+    protected void shutdown() throws InterruptedException {
+        super.shutdown();
+        dao.close();
+    }
 }

--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
@@ -104,7 +104,7 @@ public class DiskSpoolDAO {
      * Close DAO resources.
      */
     public void close() {
-        try (LockScope ls = LockScope.lock(connectionLock.readLock())) {
+        try (LockScope ls = LockScope.lock(connectionLock.writeLock())) {
             if (connection != null) {
                 try {
                     connection.close();

--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
@@ -50,8 +50,8 @@ public class DiskSpoolDAO {
     private static final ObjectMapper MAPPER = SerializerFactory.getFailSafeJsonObjectMapper();
     private static final RetryUtils.RetryConfig sqlStatementRetryConfig =
             RetryUtils.RetryConfig.builder()
-                    .initialRetryInterval(Duration.ofSeconds(1L))
-                    .maxRetryInterval(Duration.ofSeconds(3L))
+                    .initialRetryInterval(Duration.ofMillis(1L))
+                    .maxRetryInterval(Duration.ofMillis(500L))
                     .maxAttempt(3)
                     .retryableExceptions(Collections.singletonList(SQLTransientException.class))
                     .build();

--- a/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOFake.java
+++ b/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOFake.java
@@ -21,8 +21,8 @@ public class DiskSpoolDAOFake extends DiskSpoolDAO {
     @Getter
     private final ConnectionFake connection = new ConnectionFake();
 
-    public DiskSpoolDAOFake(Path rootDir) {
-        super(rootDir.resolve("spooler.db"));
+    public DiskSpoolDAOFake(Path path) {
+        super(path);
     }
 
     @Override

--- a/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOTest.java
+++ b/src/test/java/com/aws/greengrass/disk/spool/DiskSpoolDAOTest.java
@@ -23,7 +23,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.SQLTransientException;
 import java.util.Iterator;
@@ -44,7 +43,7 @@ import static org.mockito.Mockito.verify;
 @ExtendWith({GGExtension.class, MockitoExtension.class})
 class DiskSpoolDAOTest {
 
-    private static final CrashableFunction<DiskSpoolDAO, Void, SQLException> OPERATION_INSERT_SPOOL_MESSAGE = dao -> {
+    private static final CrashableFunction<DiskSpoolDAO, Void, Exception> OPERATION_INSERT_SPOOL_MESSAGE = dao -> {
         dao.insertSpoolMessage(SpoolMessage.builder()
                 .id(1L)
                 .request(Publish.builder()
@@ -59,17 +58,17 @@ class DiskSpoolDAOTest {
         return null;
     };
 
-    private static final CrashableFunction<DiskSpoolDAO, Void, SQLException> OPERATION_GET_ALL_SPOOL_MESSAGE_IDS = dao -> {
+    private static final CrashableFunction<DiskSpoolDAO, Void, Exception> OPERATION_GET_ALL_SPOOL_MESSAGE_IDS = dao -> {
         dao.getAllSpoolMessageIds();
         return null;
     };
 
-    private static final CrashableFunction<DiskSpoolDAO, Void, SQLException> OPERATION_GET_SPOOL_MESSAGE_BY_ID = dao -> {
+    private static final CrashableFunction<DiskSpoolDAO, Void, Exception> OPERATION_GET_SPOOL_MESSAGE_BY_ID = dao -> {
         dao.getSpoolMessageById(0L);
         return null;
     };
 
-    private static final CrashableFunction<DiskSpoolDAO, Void, SQLException> OPERATION_REMOVE_SPOOL_MESSAGE_BY_ID = dao -> {
+    private static final CrashableFunction<DiskSpoolDAO, Void, Exception> OPERATION_REMOVE_SPOOL_MESSAGE_BY_ID = dao -> {
         dao.removeSpoolMessageById(0L);
         return null;
     };
@@ -79,39 +78,38 @@ class DiskSpoolDAOTest {
     DiskSpoolDAOFake dao;
 
     @BeforeEach
-    void setUp() throws SQLException {
-        dao = spy(new DiskSpoolDAOFake(currDir));
+    void setUp() throws SQLException, InterruptedException {
+        dao = spy(new DiskSpoolDAOFake(currDir.resolve("spooler.db")));
+        dao.initialize();
         dao.setUpDatabase();
     }
 
     @AfterEach
-    @SuppressWarnings("PMD.CloseResource")
-    void tearDown() throws SQLException {
-        Connection conn = dao.getConnection();
-        if (conn != null) {
-            conn.close();
+    void tearDown() {
+        if (dao != null) {
+            dao.close();
         }
     }
 
     @Test
-    void GIVEN_empty_spooler_WHEN_messages_added_and_removed_from_spooler_THEN_success() throws SQLException {
+    void GIVEN_empty_spooler_WHEN_messages_added_and_removed_from_spooler_THEN_success() throws SQLException, InterruptedException {
         List<Long> messageIds = LongStream.range(0, 100L).boxed().collect(Collectors.toList());
 
         // fill db with messages
         for (long id : messageIds) {
-            dao.insertSpoolMessage(
-                    SpoolMessage.builder()
-                            .id(id)
-                            .request(
-                                    Publish.builder()
-                                            .topic("spool")
-                                            .payload("Hello".getBytes(StandardCharsets.UTF_8))
-                                            .qos(QOS.AT_LEAST_ONCE)
-                                            .messageExpiryIntervalSeconds(2L)
-                                            .payloadFormat(Publish.PayloadFormatIndicator.BYTES)
-                                            .contentType("Test")
-                                            .build())
-                            .build());
+            SpoolMessage message = SpoolMessage.builder()
+                    .id(id)
+                    .request(
+                            Publish.builder()
+                                    .topic("spool")
+                                    .payload("Hello".getBytes(StandardCharsets.UTF_8))
+                                    .qos(QOS.AT_LEAST_ONCE)
+                                    .messageExpiryIntervalSeconds(2L)
+                                    .payloadFormat(Publish.PayloadFormatIndicator.BYTES)
+                                    .contentType("Test")
+                                    .build())
+                    .build();
+            dao.insertSpoolMessage(message);
             // verify message exists
             assertNotNull(dao.getSpoolMessageById(id));
         }
@@ -119,7 +117,7 @@ class DiskSpoolDAOTest {
         // verify getting all ids
         int numMessagesChecked = 0;
         Iterator<Long> persistedIds = dao.getAllSpoolMessageIds().iterator();
-        for (int i = 0; i < messageIds.size(); i++, numMessagesChecked++) {
+        for (int i = 0; persistedIds.hasNext(); i++, numMessagesChecked++) {
             assertEquals(messageIds.get(i), persistedIds.next());
         }
         assertEquals(messageIds.size(), numMessagesChecked);
@@ -132,8 +130,8 @@ class DiskSpoolDAOTest {
     }
 
     @ParameterizedTest
-    @MethodSource("corruptionDetectingSpoolerOperations")
-    void GIVEN_spooler_WHEN_corruption_detected_during_operation_THEN_spooler_recovers(CrashableFunction<DiskSpoolDAO, Void, SQLException> operation) throws SQLException {
+    @MethodSource("allSpoolerOperations")
+    void GIVEN_spooler_WHEN_corruption_detected_during_operation_THEN_spooler_recovers(CrashableFunction<DiskSpoolDAO, Void, SQLException> operation) throws SQLException, InterruptedException {
         SQLException corruptionException = new SQLException("DB is corrupt", "some state", 11);
         dao.getConnection().addExceptionOnUpdate(corruptionException);
         assertThrows(SQLException.class, () -> operation.apply(dao));
@@ -143,21 +141,13 @@ class DiskSpoolDAOTest {
 
     @ParameterizedTest
     @MethodSource("allSpoolerOperations")
-    void GIVEN_spooler_WHEN_transient_error_during_operation_THEN_operation_retried(CrashableFunction<DiskSpoolDAO, Void, SQLException> operation, ExtensionContext context) throws SQLException {
+    void GIVEN_spooler_WHEN_transient_error_during_operation_THEN_operation_retried(CrashableFunction<DiskSpoolDAO, Void, SQLException> operation, ExtensionContext context) throws SQLException, InterruptedException {
         ignoreExceptionOfType(context, SQLTransientException.class);
         SQLException transientException = new SQLTransientException("Some Transient Error");
         dao.getConnection().addExceptionOnUpdate(transientException);
         dao.getConnection().addExceptionOnUpdate(transientException);
         operation.apply(dao);
         verify(dao, never()).checkAndHandleCorruption(transientException);
-    }
-
-    public static Stream<Arguments> corruptionDetectingSpoolerOperations() {
-        return Stream.of(
-                Arguments.of(OPERATION_INSERT_SPOOL_MESSAGE),
-                Arguments.of(OPERATION_GET_ALL_SPOOL_MESSAGE_IDS),
-                Arguments.of(OPERATION_GET_SPOOL_MESSAGE_BY_ID)
-        );
     }
 
     public static Stream<Arguments> allSpoolerOperations() {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Rather than create a new db connection for every spooler operation, use a single connection.

Also adds corruption detection for "NOTADB" errors, which can happen depending on how the db file is corrupted.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
