### PR TITLE
fix: bring back driver registration

### DIFF
--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
@@ -98,6 +98,7 @@ public class DiskSpoolDAO {
      * @throws SQLException if database is unable to be created
      */
     public void initialize() throws SQLException {
+        registerDriver();
         try (LockScope ls = LockScope.lock(connectionLock.writeLock())) {
             close();
             connection = createConnection();
@@ -113,6 +114,16 @@ public class DiskSpoolDAO {
                 }
                 statement.replaceStatement(connection);
             }
+        }
+    }
+
+    private void registerDriver() throws SQLException {
+        try {
+            // driver is registered statically within JDBC,
+            // so it will only happen once
+            Class.forName("org.sqlite.JDBC");
+        } catch (ClassNotFoundException e) {
+            throw new SQLException("unable to load driver", e);
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While passing in local unit/integration tests, https://github.com/aws-greengrass/aws-greengrass-disk-spooler/pull/36 broke UATs due to driver not being registered.

```
java.io.IOException: java.sql.SQLException: No suitable driver found for jdbc:sqlite:/home/ec2-user/testResults/23a8fe84c2b77e4bcf9352b2925df0db9fd6d40b/work/aws.greengrass.DiskSpooler/spooler.db
```

This change brings back registration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
