### PR TITLE
fix: prevent concurrent result sets for a statement

### DIFF
--- a/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
+++ b/src/main/java/com/aws/greengrass/disk/spool/DiskSpoolDAO.java
@@ -157,7 +157,7 @@ public class DiskSpoolDAO {
      * @return ordered iterable of message ids
      * @throws SQLException if statement failed to execute, or when unable to read results
      */
-    public Iterable<Long> getAllSpoolMessageIds() throws SQLException {
+    public synchronized Iterable<Long> getAllSpoolMessageIds() throws SQLException {
         try (ResultSet rs = getAllSpoolMessageIds.execute()) {
             return getAllSpoolMessageIds.mapResultToIds(rs);
         }
@@ -170,7 +170,7 @@ public class DiskSpoolDAO {
      * @return  message
      * @throws SQLException if statement failed to execute, or when unable to read results
      */
-    public SpoolMessage getSpoolMessageById(long id) throws SQLException {
+    public synchronized SpoolMessage getSpoolMessageById(long id) throws SQLException {
         try (ResultSet rs = getSpoolMessageById.executeWithParameters(id)) {
             return getSpoolMessageById.mapResultToMessage(id, rs);
         } catch (IOException e) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Since moving to cached connections, we've began seeing `java.sql.SQLException: ResultSet already requested` failures in UATs. This change synchronizes `getSpoolMessageById` and `getAllSpoolMessageIds` to ensure there's one result set being operated on for a given statement  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
